### PR TITLE
Refactor InferenceDataset creation

### DIFF
--- a/src/zap/classification/data_modules.py
+++ b/src/zap/classification/data_modules.py
@@ -13,11 +13,9 @@ from .dataset import ClassificationDataset
 
 class ClassificationDataModule(ZapDataModule):
     def __init__(self, data_dir, transforms, train_split=0.7, test_split=0.2, val_split=0.1,
-                 batch_size=1, num_workers=0, pin_memory=True, shuffle=True, collate_fn=None):
-        super().__init__()
-
+                 batch_size=1, num_workers=0, pin_memory=True, shuffle=True):
+        
         self.data_dir = Path(data_dir)
-
         self.image_dir = self.data_dir.joinpath('images')
         self.images = list(self.image_dir.glob('*.*'))
 
@@ -37,7 +35,7 @@ class ClassificationDataModule(ZapDataModule):
         self.num_workers = num_workers
         self.pin_memory = pin_memory
         self.shuffle = shuffle
-        self.collate_fn = collate_fn
+        self.collate_fn = None
 
         filtered_images = []
         for i in self.images:
@@ -53,10 +51,6 @@ class ClassificationDataModule(ZapDataModule):
         self.train_dataset, self.test_dataset, self.val_dataset = random_split(
             dataset, [train_split, test_split, val_split], generator)
 
-        self.predict_dir = Path(data_dir, 'predict', 'images')
-        prediction_images = list(self.predict_dir.glob(
-            '*.png')) + list(self.predict_dir.glob('*.jpg'))
-        self.predict_dataset = InferenceDataset(
-            prediction_images, transform=self.transforms)
 
+        super().__init__()  # important to initialise here
         self.save_hyperparameters()

--- a/src/zap/classification/dataset.py
+++ b/src/zap/classification/dataset.py
@@ -6,11 +6,11 @@ from torch.utils.data import Dataset
 
 
 class ClassificationDataset(Dataset):
-    def __init__(self, images, labels, label_map, transform=None) -> None:
+    def __init__(self, images, labels, label_map, transforms=None) -> None:
         self.images = images
         self.labels = labels
         self.label_map = label_map
-        self.transform = transform
+        self.transforms = transforms
         super().__init__()
 
     def __len__(self):
@@ -23,7 +23,7 @@ class ClassificationDataset(Dataset):
         label = self.labels.loc[self.images[index].name, 'label']
         label = self.label_map[label]
 
-        if self.transform is not None:
-            img = self.transform(img)
+        if self.transforms is not None:
+            img = self.transforms(img)
 
         return img, label

--- a/src/zap/classification/models.py
+++ b/src/zap/classification/models.py
@@ -21,8 +21,8 @@ class ResNet34(pl.LightningModule):
         self.multiclass_precision = MulticlassPrecision(num_classes=num_classes, average=None)
         self.multiclass_recall = MulticlassRecall(num_classes=num_classes, average=None)
 
-    def forward(self, x):
-        pred = self.model(x)
+    def forward(self, batch):
+        pred = self.model(batch)
         probabilities = nn.functional.softmax(pred, dim=1)
         return probabilities
 

--- a/src/zap/object_detection/data_modules.py
+++ b/src/zap/object_detection/data_modules.py
@@ -41,7 +41,6 @@ from .dataset import DETADataset, FasterRCNNDataset
 class DETADataModule(ZapDataModule):
     def __init__(self, data_dir, size, batch_size=1, num_workers=0, pin_memory=True, transforms=None,
                  shuffle=True, train_split=0.7, test_split=0.2, val_split=0.1, converter=None):
-        super().__init__()
 
         if converter:
             converter_fn = parse_module_from_string(converter)
@@ -53,6 +52,7 @@ class DETADataModule(ZapDataModule):
                 "shortest_edge": size[0],
                 "longest_edge": size[1]})
 
+        self.data_dir = Path(data_dir)
         self.batch_size = batch_size
         self.num_workers = num_workers
         self.pin_memory = pin_memory
@@ -63,8 +63,8 @@ class DETADataModule(ZapDataModule):
         self.transforms = Compose(transforms) if transforms else None
 
         dataset = DETADataset(
-            img_folder=Path(data_dir, 'images'),
-            ann_file=Path(data_dir, 'labels.json'),
+            img_folder=self.data_dir / 'images',
+            ann_file=self.data_dir / 'labels.json',
             processor=self.processor)
 
         self.label_map = dataset.label_map
@@ -73,11 +73,7 @@ class DETADataModule(ZapDataModule):
         self.train_dataset, self.test_dataset, self.val_dataset = random_split(
             dataset, [train_split, test_split, val_split], generator)
 
-        self.predict_dir = Path(data_dir, 'predict', 'images')
-        prediction_images = list(self.predict_dir.glob('*.png')) + list(self.predict_dir.glob('*.jpg'))
-        # TODO: rename transforms to be consistent
-        self.predict_dataset = InferenceDataset(prediction_images, transform=self.transforms)
-
+        super().__init__()
         self.save_hyperparameters()
 
     def collate_fn(self, batch):
@@ -98,8 +94,8 @@ class DETADataModule(ZapDataModule):
 class FasterRCNNDataModule(ZapDataModule):
     def __init__(self, data_dir, batch_size=1, num_workers=0, pin_memory=True, transforms=None,
                  shuffle=True, train_split=0.7, test_split=0.2, val_split=0.1):
-        super().__init__()
 
+        self.data_dir = Path(data_dir)
         self.batch_size = batch_size
         self.num_workers = num_workers
         self.pin_memory = pin_memory
@@ -109,8 +105,8 @@ class FasterRCNNDataModule(ZapDataModule):
         self.transforms = FasterRCNN_ResNet50_FPN_V2_Weights.DEFAULT.transforms()
 
         dataset = FasterRCNNDataset(
-            img_folder=Path(data_dir, 'images'),
-            ann_file=Path(data_dir, 'labels.json'),
+            img_folder=self.data_dir / 'images',
+            ann_file=self.data_dir / 'labels.json',
             transforms=self.transforms)
 
         self.label_map = dataset.label_map
@@ -119,11 +115,7 @@ class FasterRCNNDataModule(ZapDataModule):
         self.train_dataset, self.test_dataset, self.val_dataset = random_split(
             dataset, [train_split, test_split, val_split], generator)
 
-        self.predict_dir = Path(data_dir, 'predict', 'images')
-        prediction_images = list(self.predict_dir.glob('*.png')) + list(self.predict_dir.glob('*.jpg'))
-        # TODO: rename transforms to be consistent
-        self.predict_dataset = InferenceDataset(prediction_images, transform=self.transforms)
-
+        super().__init__()
         self.save_hyperparameters()
 
     def collate_fn(self, batch):

--- a/src/zap/object_detection/models.py
+++ b/src/zap/object_detection/models.py
@@ -161,11 +161,8 @@ class FasterRCNN(ZapModel):
         return super().configure_optimizers()
 
     def forward(self, batch):
-        input_data = batch[0]
-        filenames = batch[1]
-
-        preds = self.model(input_data)
-        return tuple(zip(preds, filenames))
+        preds = self.model(batch)
+        return preds
 
     def common_step(self, batch):
         images, targets, filenames = batch

--- a/src/zap/segmentation/data_modules.py
+++ b/src/zap/segmentation/data_modules.py
@@ -5,14 +5,13 @@ from torch import Generator
 from torch.utils.data import random_split
 from torchvision.transforms import Compose
 
-from .. import InferenceDataset, ZapDataModule
+from .. import ZapDataModule
 from .dataset import SegmentationDataset
 
 
 class SegmentationDataModule(ZapDataModule):
     def __init__(self, data_dir, transforms, train_split=0.7, test_split=0.2, val_split=0.1,
                  batch_size=1, num_workers=0, pin_memory=True, shuffle=True, collate_fn=None):
-        super().__init__()
 
         self.data_dir = Path(data_dir)
 
@@ -32,17 +31,11 @@ class SegmentationDataModule(ZapDataModule):
         self.collate_fn = collate_fn
 
         dataset = SegmentationDataset(
-            self.images, self.masks, transform=self.transforms)
+            self.images, self.masks, transforms=self.transforms)
         #  TODO: look into using sklearn.model_selection.train_test_split instead
         generator = Generator()
         self.train_dataset, self.test_dataset, self.val_dataset = random_split(
             dataset, [train_split, test_split, val_split], generator)
 
-        # TODO: cleanup
-        self.predict_dir = Path(data_dir, 'predict', 'images')
-        prediction_images = list(self.predict_dir.glob(
-            '*.png')) + list(self.predict_dir.glob('*.jpg'))
-        self.predict_dataset = InferenceDataset(
-            prediction_images, transform=self.transforms)
-
+        super().__init__()
         self.save_hyperparameters()

--- a/src/zap/segmentation/dataset.py
+++ b/src/zap/segmentation/dataset.py
@@ -5,10 +5,10 @@ from torch.utils.data import Dataset
 
 
 class SegmentationDataset(Dataset):
-    def __init__(self, images, masks, transform=None) -> None:
+    def __init__(self, images, masks, transforms=None) -> None:
         self.images = images
         self.masks = masks
-        self.transform = transform
+        self.transforms = transform
         super().__init__()
 
     def __len__(self):
@@ -18,7 +18,7 @@ class SegmentationDataset(Dataset):
         img = Image.open(self.images[index]).convert('RGB')
         mask = Image.open(self.masks[index]).convert('L')
 
-        if self.transform is not None:
+        if self.transforms is not None:
             img = self.transform(img)
             mask = self.transform(mask)
 


### PR DESCRIPTION
This PR started off as a way to fix ResNet34 classification inference. It ultimately resulted in refactoring the `InferenceDataset` and changing how we deal with image names as a whole (when creating inference scripts)

- Removes filename from `InferenceDataset` as it was causing too many headaches with `collate_fn` across different models/archs
- Moved the creation of a prediction dataset into the base `ZapDataModule` instead of creating it separately for each model. We now expose the batched prediction images so that you can reference them in your inference scripts and pair them with the results:
```python
results = z.predict(ckpt_path='checkpoint.ckpt')
prediction_images = z.cli.datamodule.prediction_images
```
- Renamed `transform` arg to `transforms` across Zap to be consistent
- Updated `FRCNN` model's `forward` method to no longer deal with filenames (since they won't be coming through)
