### PR TITLE
Fixed collate_fn requirements for DETA

### DIFF
--- a/src/zap/object_detection/data_modules.py
+++ b/src/zap/object_detection/data_modules.py
@@ -76,6 +76,15 @@ class DETADataModule(ZapDataModule):
         super().__init__()
         self.save_hyperparameters()
 
+    def predict_collate_fn(self, batch):
+        pixel_values = []
+        for img in batch:
+            encoding = self.processor(images=img, return_tensors="pt")
+            pixel_values.append(encoding["pixel_values"].squeeze())
+
+        encoding = self.processor.pad(pixel_values, return_tensors="pt")
+        return encoding['pixel_values']
+
     def collate_fn(self, batch):
         file_names = [item[2] for item in batch]
         pixel_values = [item[0] for item in batch]


### PR DESCRIPTION
- DETA data module now defines `predict_collate_fn`
    - this means we no longer need to specify `ToTensor` and `Resize` transforms in a separate config file
- ZapDataModule now checks if `predict_collate_fn` exists and uses it in the prediction DataLoader, otherwise sets to `None` 

----


Fixes sc-4125