### PR TITLE
Fix classification inference requirements

### DIFF
--- a/src/zap/__init__.py
+++ b/src/zap/__init__.py
@@ -1,7 +1,6 @@
 import os
 
 from dotenv import load_dotenv
-from lightning.pytorch.loggers import MLFlowLogger
 
 from .formatter import (format_lightning_warnings_and_logs,
                         supress_pydantic_warnings)
@@ -75,7 +74,6 @@ class ZapModel(LightningModule):
         classes = precision.pop('classes', None)  # get the classes but don't log them
 
         for k, v in precision.items():
-            print('>>>>>', k, v)
             k = k.replace('map', 'mAP').replace('mar', 'mAR')
             class_values = v.tolist()
 

--- a/src/zap/classification/data_modules.py
+++ b/src/zap/classification/data_modules.py
@@ -6,28 +6,23 @@ from torch import Generator
 from torch.utils.data import random_split
 from torchvision.transforms import Compose
 
-from .. import InferenceDataset, ZapDataModule
-from ..utils import get_label_map
+from .. import ZapDataModule
 from .dataset import ClassificationDataset
 
 
 class ClassificationDataModule(ZapDataModule):
-    def __init__(self, data_dir, transforms, train_split=0.7, test_split=0.2, val_split=0.1,
+    def __init__(self, data_dir, label_map, transforms, train_split=0.7, test_split=0.2, val_split=0.1,
                  batch_size=1, num_workers=0, pin_memory=True, shuffle=True):
-        
+
         self.data_dir = Path(data_dir)
         self.image_dir = self.data_dir.joinpath('images')
         self.images = list(self.image_dir.glob('*.*'))
+        self.train_split = train_split
+        self.test_split = test_split
+        self.val_split = val_split
 
-        self.label_map, self.label_map_reversed = get_label_map(
-            self.data_dir.joinpath('label_map.json'))
-        self.labels_df = pd.read_csv(self.data_dir.joinpath('labels.csv'))
-        self.labels_df['image'] = self.labels_df['image'].apply(
-            lambda x: os.path.basename(x))
-        self.labels_df = self.labels_df.drop_duplicates()  # TODO: raise warnings
-        self.labels_df = self.labels_df.dropna()
-        self.labels_df = self.labels_df.set_index('image')
-        self.labels_df = self.labels_df[['label']]
+        self.label_map = label_map
+        self.label_map_reversed = {v: k for k, v in label_map.items()}
 
         self.transforms = Compose(transforms)
 
@@ -36,6 +31,21 @@ class ClassificationDataModule(ZapDataModule):
         self.pin_memory = pin_memory
         self.shuffle = shuffle
         self.collate_fn = None
+
+        super().__init__()  # important to initialise here
+        self.save_hyperparameters()
+
+    def setup(self, stage):
+        if stage == 'predict':
+            return
+
+        self.labels_df = pd.read_csv(self.data_dir.joinpath('labels.csv'))
+        self.labels_df['image'] = self.labels_df['image'].apply(
+            lambda x: os.path.basename(x))
+        self.labels_df = self.labels_df.drop_duplicates()  # TODO: raise warnings
+        self.labels_df = self.labels_df.dropna()
+        self.labels_df = self.labels_df.set_index('image')
+        self.labels_df = self.labels_df[['label']]
 
         filtered_images = []
         for i in self.images:
@@ -49,8 +59,4 @@ class ClassificationDataModule(ZapDataModule):
         #  TODO: look into using sklearn.model_selection.train_test_split instead
         generator = Generator()
         self.train_dataset, self.test_dataset, self.val_dataset = random_split(
-            dataset, [train_split, test_split, val_split], generator)
-
-
-        super().__init__()  # important to initialise here
-        self.save_hyperparameters()
+            dataset, [self.train_split, self.test_split, self.val_split], generator)

--- a/src/zap/classification/models.py
+++ b/src/zap/classification/models.py
@@ -1,7 +1,6 @@
 
 from typing import Any
 
-import lightning.pytorch as pl
 import torch
 import torch.nn as nn
 import torchvision.models as models

--- a/src/zap/classification/models.py
+++ b/src/zap/classification/models.py
@@ -7,17 +7,20 @@ import torch.nn as nn
 import torchvision.models as models
 from torchmetrics.classification import MulticlassPrecision, MulticlassRecall
 
+from zap import ZapModel
+
 
 # TODO: can we make this dynamic in terms of which ResNet is used like we did in kai-classification?
-class ResNet34(pl.LightningModule):
+class ResNet34(ZapModel):
     def __init__(self, num_classes, bias):
-        super().__init__()
+        self.task = 'classification'
+
+        super().__init__()  # anything before this call can be back-referenced in the parent class
+        self.save_hyperparameters()
 
         self.model = models.resnet.resnet34(weights="DEFAULT")
         self.model.fc = torch.nn.Linear(in_features=512, out_features=num_classes, bias=bias)
-
         self.loss_fn = torch.nn.CrossEntropyLoss()
-        self.save_hyperparameters()
         self.multiclass_precision = MulticlassPrecision(num_classes=num_classes, average=None)
         self.multiclass_recall = MulticlassRecall(num_classes=num_classes, average=None)
 
@@ -51,11 +54,9 @@ class ResNet34(pl.LightningModule):
 
         self.multiclass_precision(output, label)
         self.multiclass_recall(output, label)
-        
-    
+
     def on_test_epoch_start(self) -> None:
         self.label_map_reversed = self.trainer.datamodule.label_map_reversed
-        
 
     def on_test_end(self):
         mcp = self.multiclass_precision.compute()
@@ -66,5 +67,3 @@ class ResNet34(pl.LightningModule):
         for i, m in enumerate(metrics):
             self.logger.experiment.log_metric(run_id, f'precision_{self.label_map_reversed[i]}', m[0])
             self.logger.experiment.log_metric(run_id, f'recall_{self.label_map_reversed[i]}', m[1])
-
-

--- a/src/zap/object_detection/models.py
+++ b/src/zap/object_detection/models.py
@@ -38,6 +38,7 @@ from .. import ZapModel
 
 class Deta(ZapModel):
     def __init__(self, lr, lr_backbone, weight_decay, num_classes):
+        self.task = 'object_detection'
         super().__init__()
         # replace COCO classification head with custom head
         # we specify the "no_timm" variant here to not rely on the timm library
@@ -119,7 +120,7 @@ class Deta(ZapModel):
         target_sizes = []
         for n in range(len(labels)):
             H, W = labels[n]['orig_size'].tolist()
-            
+
             # rename labels key
             labels[n]['labels'] = labels[n].pop('class_labels')
 
@@ -148,6 +149,7 @@ class Deta(ZapModel):
 
 class FasterRCNN(ZapModel):
     def __init__(self, num_classes):
+        self.task = 'object_detection'
         super().__init__()
 
         self.model = fasterrcnn_resnet50_fpn_v2(weights=FasterRCNN_ResNet50_FPN_V2_Weights.DEFAULT)


### PR DESCRIPTION
Before, to run inference with a ResNet34 model you actually had to have *a* `labels.csv` file and a `label_map.json` file present in your data directory. The labelmap is understandable but the training dataset wasn't so this PR fixes this.

Changes:

- `labels_df` is now created in the `setup` call, meaning we don't need it for inference
- the label map is now required as part of the `ClassificationDataModule` and is required in the YAML
- logging of `train_dataset`, `test_dataset` and `val_dataset` params has moved to `ZapModel.on_fit_end` because these are no longer created in `ClassificationDataModule.__init__` which made them innaccessible
- added a `task` attribute to all models (apart from segmentation models 🤫 ) that helps log only metric relevant to that type of task (e.g: classification models don't need to create/log a `mAP` metric)

