### PR TITLE
Inference runs no longer pollute MLFlow

### DIFF
--- a/src/zap/__init__.py
+++ b/src/zap/__init__.py
@@ -7,7 +7,7 @@ from .formatter import (format_lightning_warnings_and_logs,
 
 supress_pydantic_warnings()  # noqa
 
-from typing import Any, Dict  # noqa
+from typing import Any  # noqa
 
 from lightning.pytorch import LightningDataModule, LightningModule  # noqa
 from lightning.pytorch.cli import LightningCLI  # noqa

--- a/src/zap/__init__.py
+++ b/src/zap/__init__.py
@@ -7,7 +7,7 @@ from .formatter import (format_lightning_warnings_and_logs,
 
 supress_pydantic_warnings()  # noqa
 
-from typing import Any  # noqa
+from typing import Any, Dict  # noqa
 
 from lightning.pytorch import LightningDataModule, LightningModule  # noqa
 from lightning.pytorch.cli import LightningCLI  # noqa
@@ -30,10 +30,6 @@ class Zap():
                                                "default_config_files": [base_config_path]})
         self.config = self.cli.config.as_dict()
 
-        self.cli.trainer.logger.log_hyperparams({'zap_model': self.config['model']['class_path'].split('.')[-1]})
-        self.cli.trainer.logger.log_hyperparams({'optimizer': self.config.get('optimizer')})
-        self.cli.trainer.logger.log_hyperparams({'optimizer': self.config.get('optimizer')})
-
     def fit(self):
         self.cli.trainer.fit(self.cli.model, self.cli.datamodule)
 
@@ -41,11 +37,15 @@ class Zap():
         self.cli.trainer.test(self.cli.model, self.cli.datamodule, ckpt_path=ckpt_path)
 
     def predict(self, ckpt_path="last"):
+        # Not sure if there's a better way but this fixes prediction runs being logged in MLFlow
+        self.cli.trainer.logger = None
+
         preds = self.cli.trainer.predict(
             self.cli.model,
             self.cli.datamodule,
             return_predictions=True,
             ckpt_path=ckpt_path)
+
         return preds
 
 
@@ -59,11 +59,16 @@ class ZapModel(LightningModule):
         if self.task == 'object_detection':
             self.mAP = MeanAveragePrecision(class_metrics=True)
 
-    def on_fit_end(self) -> None:
-        self.logger.experiment.log_param(self.logger.run_id, 'task', self.trainer.model.task)
-        self.logger.experiment.log_param(self.logger.run_id, 'train_set', len(self.trainer.datamodule.train_dataset))
-        self.logger.experiment.log_param(self.logger.run_id, 'test_set', len(self.trainer.datamodule.test_dataset))
-        self.logger.experiment.log_param(self.logger.run_id, 'val_set', len(self.trainer.datamodule.val_dataset))
+    def on_fit_start(self) -> None:
+        run_id = self.logger.run_id
+
+        self.logger.experiment.log_param(run_id, 'zap_model',
+                                         self.trainer.model.__class__.__name__.split('.')[-1])
+        self.logger.experiment.log_param(run_id, 'optimizers', self.optimizers())
+        self.logger.experiment.log_param(run_id, 'task', self.trainer.model.task)
+        self.logger.experiment.log_param(run_id, 'train_set', len(self.trainer.datamodule.train_dataset))
+        self.logger.experiment.log_param(run_id, 'test_set', len(self.trainer.datamodule.test_dataset))
+        self.logger.experiment.log_param(run_id, 'val_set', len(self.trainer.datamodule.val_dataset))
 
     def on_test_epoch_start(self) -> None:
         self.label_map = self.trainer.datamodule.label_map

--- a/src/zap/object_detection/models.py
+++ b/src/zap/object_detection/models.py
@@ -61,14 +61,12 @@ class Deta(ZapModel):
 
     def configure_optimizers(self):
         param_dicts = [
-            {"params": [p for n, p in self.named_parameters() if "backbone" not in n and p.requires_grad]},
             {
                 "params": [p for n, p in self.named_parameters() if "backbone" in n and p.requires_grad],
                 "lr": self.lr_backbone,
             },
         ]
-        optimizer = torch.optim.AdamW(param_dicts, lr=self.lr,
-                                      weight_decay=self.weight_decay)
+        optimizer = torch.optim.AdamW(param_dicts, lr=self.lr, weight_decay=self.weight_decay)
         return optimizer
 
     def forward(self, pixel_values, pixel_mask=None):


### PR DESCRIPTION
Changes:

- Moved logging away from `Zap.__init__` and into `ZapModel.on_fit_start`
- Set `self.cli.trainer.logger` to `None` in `Zap.predict` to swiftly disable any logging during predictions
    - Not sure if that is the best way to do this, but I was unable to track exactly where the MLFlow run is created. According to the docs, it shouldn't be. 
- Fixed a bug in DETA that was creating two separate parameter groups for its optimizer
- Optimizer info is now logged in a slightly different way