### PR TITLE
User's FRCNN transforms are now respected

### DIFF
--- a/src/zap/object_detection/data_modules.py
+++ b/src/zap/object_detection/data_modules.py
@@ -110,8 +110,10 @@ class FasterRCNNDataModule(ZapDataModule):
         self.pin_memory = pin_memory
         self.shuffle = shuffle
 
-        # TODO: need to incorporate user given transforms
-        self.transforms = FasterRCNN_ResNet50_FPN_V2_Weights.DEFAULT.transforms()
+        # NOTE: default transforms are not compatible with ToTensor; should warn user?
+        # NOTE: from testing on generated dataset, anything other than the default transforms yields terrible results
+        default_transforms = FasterRCNN_ResNet50_FPN_V2_Weights.DEFAULT.transforms()
+        self.transforms = Compose([default_transforms, *transforms])
 
         dataset = FasterRCNNDataset(
             img_folder=self.data_dir / 'images',


### PR DESCRIPTION
Changes:

- Now using `Compose` to combine the model's default transforms with the user given ones

Does NOT work with user provided `ToTensor`. Need to add to README.
From testing on generated dataset, results with anything other than just the default transforms are worse.